### PR TITLE
[CH-01]: Multiple passengers.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.2",
         "express": "^4.18.2",
-        "redis": "^4.6.13",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.3.3"
+        "redis": "^4.6.13"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -28,8 +26,10 @@
         "jest": "^29.7.0",
         "supertest": "^6.3.4",
         "ts-jest": "^29.1.2",
+        "ts-node": "^10.9.2",
         "ts-standard": "^12.0.2",
-        "tsconfig-paths": "^4.2.0"
+        "tsconfig-paths": "^4.2.0",
+        "typescript": "^5.3.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -726,6 +726,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -737,6 +738,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1243,6 +1245,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1259,7 +1262,8 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.22",
@@ -1391,22 +1395,26 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1584,6 +1592,7 @@
       "version": "20.11.20",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.20.tgz",
       "integrity": "sha512-7/rR21OS+fq8IyHTgtLkDK949uzsa6n8BkziAKtPVpugIkO6D+/ooXMvzXxDnZrmtXVfjb1bKQafYpb8s89LOg==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2080,6 +2089,7 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2100,6 +2110,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2175,7 +2186,8 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -2917,7 +2929,8 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3052,6 +3065,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -6150,7 +6164,8 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -7915,6 +7930,7 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -8148,6 +8164,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8174,7 +8191,8 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -8234,7 +8252,8 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -8449,6 +8468,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }

--- a/src/checkin/model/Schema.ts
+++ b/src/checkin/model/Schema.ts
@@ -2,6 +2,7 @@ export type RequiredField =
   | 'passport_number'
   | 'passenger_names'
   | 'agreement_required'
+  | 'extra_passenger_information'
 
 export type CountryCode =
   | 'AF'

--- a/src/checkin/model/session/ExtraPassengerInformation.ts
+++ b/src/checkin/model/session/ExtraPassengerInformation.ts
@@ -1,0 +1,4 @@
+export default interface ExtraPassengerInformation {
+  name: string
+  passport: string
+}

--- a/src/checkin/model/session/SessionData.ts
+++ b/src/checkin/model/session/SessionData.ts
@@ -1,4 +1,5 @@
 import { CountryCode } from '../Schema'
+import ExtraPassengerInformation from './ExtraPassengerInformation'
 import { FlightData } from './FlightData'
 
 export interface SessionData {
@@ -6,4 +7,5 @@ export interface SessionData {
   flights: FlightData[]
   passengers: number
   agreementSigned?: boolean
+  extra_passenger_information?: ExtraPassengerInformation[]
 }

--- a/src/checkin/services/CheckInFlow.ts
+++ b/src/checkin/services/CheckInFlow.ts
@@ -3,6 +3,7 @@ import FlowExecuter from './flow/FlowExecuter'
 import FlowStrategy from './flow/FlowStrategy'
 import AgreementSignStep from './flow/step/AgreementSignStep'
 import CompleteCheckinStep from './flow/step/CompleteCheckinStep'
+import GetExtraPassengerInformationStep from './flow/step/GetExtraPassengerInformationStep'
 import PassportInformationStep from './flow/step/PassportInformationStep'
 import ValidateSessionStep from './flow/step/ValidateSessionStep'
 
@@ -12,6 +13,7 @@ export default class CheckinFlow extends FlowStrategy {
     flowExecuter
       .and(new ValidateSessionStep())
       .and(new PassportInformationStep())
+      .and(new GetExtraPassengerInformationStep())
       .and(new AgreementSignStep())
       .and(new CompleteCheckinStep())
 

--- a/src/checkin/services/CheckinFlow.spec.ts
+++ b/src/checkin/services/CheckinFlow.spec.ts
@@ -22,6 +22,7 @@ describe('[ Services / CheckInFlow ]', () => {
     const expectedSteps = [
       'ValidateSessionStep',
       'PassportInformationStep',
+      'GetExtraPassengerInformationStep',
       'AgreementSignStep',
       'CompleteCheckinStep'
     ]
@@ -30,7 +31,7 @@ describe('[ Services / CheckInFlow ]', () => {
 
     await checkinFlow.checkIn(flowExecuterMock, requestData)
 
-    expect(flowExecuterMock.and).toHaveBeenCalledTimes(4)
+    expect(flowExecuterMock.and).toHaveBeenCalledTimes(5)
     expect(flowExecuterMock.getStepsExecution()).toEqual(expectedSteps)
   })
 })

--- a/src/checkin/services/flow/step/GetExtraPassengerInformationStep.spec.ts
+++ b/src/checkin/services/flow/step/GetExtraPassengerInformationStep.spec.ts
@@ -1,0 +1,101 @@
+import { MockContext } from '@testMocks/model/Context.mock'
+import { Context } from '../../../model/Context'
+import GetExtraPassengerInformationStep from './GetExtraPassengerInformationStep'
+import ExtraPassengerInformation from '../../../model/session/ExtraPassengerInformation'
+import random from '../../../../../util/random'
+
+describe('[ Step / GetExtraPassengerInformationStep ]', () => {
+  const step = new GetExtraPassengerInformationStep()
+
+  describe('Test when it should be execute', () => {
+    it('should execute when passengers are more than one and extra passengers info not defined in session data', () => {
+
+      const context = wireContextMockWithNumberOfPassengersInSessionData(2)
+
+      expect(step.when(context)).toBeTruthy()
+    })
+
+    it('should not execute when there is only one passenger or extra passengers info is defined in session data', () => {
+      const context = wireContextMockWithNumberOfPassengersInSessionData(1)
+
+      expect(step.when(context)).toBeFalsy()
+    })
+  })
+
+  describe('Test at execution', () => {
+    let context: Context
+    beforeEach(() => { context = wireContextMockWithNumberOfPassengersInSessionData(2) })
+
+    it('should request the extra passengers information', async () => {
+      wireContextMockWithNullExtraPassengerInformationInRequest(context)
+
+      const response = await step.onExecute(context)
+
+      expect(response).toBeFalsy()
+      expect(context.getResponse().requiredFiles?.extra_passenger_information).toBeNull()
+      expect(context.getSession().data.extra_passenger_information).toBeUndefined()
+    })
+
+    it('should request the exact amount of extra passengers information', async () => {
+      wireContextMockWithAmountOfExtraPassengersInformationInRequest(0, context)
+
+      const response = await step.onExecute(context)
+
+      expect(response).toBeFalsy()
+      expect(context.getResponse().requiredFiles?.extra_passenger_information).toBeNull()
+      expect(context.getSession().data.extra_passenger_information).toBeUndefined()
+    })
+
+    it('should set the extra passenger information in session if it is given by the user', async () => {
+      wireContextMockWithAmountOfExtraPassengersInformationInRequest(1, context)
+      const mockExtraPassengerInformation = context.getRequest().fields?.extra_passenger_information as ExtraPassengerInformation[]
+
+      const response = await step.onExecute(context)
+
+      expect(response).toBeTruthy()
+      expect(context.getSession().data.extra_passenger_information).toBe(mockExtraPassengerInformation)
+    })
+  })
+})
+
+function wireContextMockWithNumberOfPassengersInSessionData(numberOfPassengers: number, context = new MockContext()): Context {
+  const { country, flights, agreementSigned } = context.getSession().data
+
+  context.withSessionBuilder(sessionBuilder => sessionBuilder
+    .data({
+      country,
+      flights,
+      passengers: numberOfPassengers,
+      agreementSigned
+    })
+  )
+  return context
+}
+
+function wireContextMockWithNullExtraPassengerInformationInRequest(context = new MockContext()): Context {
+  context.withRequestBuilder(requestBuilder => requestBuilder.fields({ extra_passenger_information: null }))
+
+  return context
+}
+
+function wireContextMockWithAmountOfExtraPassengersInformationInRequest(amountOfExtraPassengersInformation: number, context = new MockContext()): Context {
+  const mockExtraPassengerInformation = buildMockExtraPassengerInformation(amountOfExtraPassengersInformation)
+
+  context.withRequestBuilder(requestBuilder => requestBuilder.fields({ extra_passenger_information: mockExtraPassengerInformation }))
+
+  return context
+}
+
+function buildMockExtraPassengerInformation(amountOfExtraPassengersInformation: number): ExtraPassengerInformation[] {
+  const mockExtraPassengerInformation: ExtraPassengerInformation[] = []
+
+  for (let i = 0; i < amountOfExtraPassengersInformation; i++) {
+    const extraPassengerInformation = {
+      name: random.getRandomName(),
+      passport: random.getRandomPassport()
+    }
+    mockExtraPassengerInformation.push(extraPassengerInformation)
+  }
+
+  return mockExtraPassengerInformation
+}

--- a/src/checkin/services/flow/step/GetExtraPassengerInformationStep.ts
+++ b/src/checkin/services/flow/step/GetExtraPassengerInformationStep.ts
@@ -1,0 +1,63 @@
+import { RequestData } from '@http/Request'
+import { Context } from '../../../model/Context'
+import { Session } from '../../../model/session'
+import ExtraPassengerInformation from '../../../model/session/ExtraPassengerInformation'
+import StepTemplate from '../StepTemplate'
+
+export default class GetExtraPassengerInformationStep extends StepTemplate {
+
+  when(context: Context): boolean {
+    const extraPassengerInformationInSession = context.getSession().data.extra_passenger_information
+    const numberOfPassengers = context.getSession().data.passengers
+
+    return numberOfPassengers > 1 && extraPassengerInformationInSession === undefined
+  }
+
+  onExecute(context: Context): Promise<boolean> {
+    const session = context.getSession()
+
+    const extraPassengerInformation = this.getExtraPassengerInformationFromRequest(context.getRequest())
+
+    if (this.validateExtraPassengerInformation(extraPassengerInformation, session)) {
+      context = this.setExtraPassengersInformationInContextRequiredFiles(context)
+      return Promise.resolve(false)
+    }
+
+    context = this.setExtraPassengerInformationInContextSession(context, extraPassengerInformation)
+
+    return Promise.resolve(true)
+  }
+
+  private getExtraPassengerInformationFromRequest(requestData: RequestData): ExtraPassengerInformation[] {
+    return requestData.fields?.extra_passenger_information as ExtraPassengerInformation[]
+  }
+
+  private validateExtraPassengerInformation(extraPassengerInformation: ExtraPassengerInformation[], session: Session): boolean {
+    const amountOfExtraPassengers = this.getAmountOfExtraPassengersInSession(session)
+
+    return !extraPassengerInformation || amountOfExtraPassengers > extraPassengerInformation.length
+  }
+
+  private getAmountOfExtraPassengersInSession(session: Session): number {
+    return session.data.passengers - 1
+  }
+
+  private setExtraPassengersInformationInContextRequiredFiles(context: Context): Context {
+    return context.withResponseBuilder((responseBuilder) => responseBuilder.status('user_information_required').requiredFiles({ extra_passenger_information: null }))
+  }
+
+  private setExtraPassengerInformationInContextSession(context: Context, extraPassengerInformation: ExtraPassengerInformation[]): Context {
+    const { country, flights, passengers, agreementSigned } = context.getSession().data
+
+    context = context.withSessionBuilder(sessionBuilder => sessionBuilder.data({
+      country,
+      flights,
+      passengers,
+      agreementSigned,
+      extra_passenger_information: extraPassengerInformation
+    }))
+
+    return context
+  }
+
+}

--- a/test/integration/framework/userInteraction.ts
+++ b/test/integration/framework/userInteraction.ts
@@ -9,6 +9,7 @@ interface RequiredData { sessionId: UUID, country: CountryCode }
 
 const initSession = async (app: Application, country: CountryCode, data?: Partial<RequestData>): Promise<UUID> => {
   const requestData = generateRequestDataMock({ country, sessionId: (null) as unknown as UUID, ...data })
+
   const initResponse = await request(app).post('/init').send(requestData)
   const { sessionId } = initResponse.body
 
@@ -19,6 +20,8 @@ const initSession = async (app: Application, country: CountryCode, data?: Partia
 }
 
 const initSessionWithPassport = (app: Application, country: CountryCode): Promise<UUID> => initSession(app, country, { fields: { passport_number: 'G123' } })
+
+const initSessionWithPassportAndExtraPassengers = (app: Application, country: CountryCode): Promise<UUID> => initSession(app, country, { passengers: 3, fields: { passport_number: 'G123' } })
 
 const continueRequest = async (app: Application, requiredData: RequiredData, data?: Partial<RequestData>): Promise<Response> => {
   const { sessionId, country } = requiredData
@@ -42,6 +45,7 @@ const signLegalAgreement = (app: Application, requiredData: RequiredData, data?:
 export default {
   initSession,
   initSessionWithPassport,
+  initSessionWithPassportAndExtraPassengers,
   continue: continueRequest,
   fillPassport,
   signLegalAgreement

--- a/test/mocks/model/RequestData.mock.ts
+++ b/test/mocks/model/RequestData.mock.ts
@@ -29,6 +29,7 @@ const generateRequestDataMock = (mockedData?: Partial<RequestData>): RequestData
       .userId(mockedData.userId ?? MOCKED_REQUEST_DATA.userId)
       .flightNumbers(mockedData.flightNumbers ?? MOCKED_REQUEST_DATA.flightNumbers)
       .fields(mockedData.fields ?? MOCKED_REQUEST_DATA.fields)
+      .passengers(mockedData.passengers ?? MOCKED_REQUEST_DATA.passengers)
   }
 
   return builder.build()

--- a/util/random.ts
+++ b/util/random.ts
@@ -1,0 +1,17 @@
+
+const MOCK_NAMES = ['Carlos', 'Juan', 'Emilio', 'Gary', 'Elias', 'Fernando', 'Giovanni']
+
+const MOCK_PASSPORTS = ['G143327', 'G113125', 'G229108', 'G229101']
+
+function getRandomName(): string {
+  return MOCK_NAMES[Math.floor(Math.random() * 10) % MOCK_NAMES.length]
+}
+
+function getRandomPassport(): string {
+  return MOCK_PASSPORTS[Math.floor(Math.random() * 10) % MOCK_PASSPORTS.length]
+}
+
+export default {
+  getRandomName,
+  getRandomPassport
+}


### PR DESCRIPTION
## Background
Right now the checking flow just accept one passenger (the user) and it's corresponding information.
It should be able to fill information for many passengers.

## Aceptance criteria:
When having extra passengers user should be requested to fill names and passports.
If no extra passengers are passed then just skip this step.

## Technical Overview.
The session already capture the number of passengers in the SessionData

When requesting continue, after the passport collection it should request a new required field, named:
`extra_passenger_information` and should be type:
```typescript
{ 
  extra_passenger_information: [ 
    { name: "name", passport: "passport"},
    ...
  ] 
}
```

This information should be saved in the session after being collected.