### PR TITLE
[CH-02]: Assign seats.

### DIFF
--- a/src/checkin/model/Schema.ts
+++ b/src/checkin/model/Schema.ts
@@ -2,6 +2,7 @@ export type RequiredField =
   | 'passport_number'
   | 'passenger_names'
   | 'agreement_required'
+  | 'seats_required'
 
 export type CountryCode =
   | 'AF'

--- a/src/checkin/model/session/FlightData.ts
+++ b/src/checkin/model/session/FlightData.ts
@@ -11,3 +11,7 @@ export interface Airport {
   name: string
   country: CountryCode
 }
+export interface SeatInformation {
+  seatNumber: string
+  flight: string
+}

--- a/src/checkin/model/session/SessionData.ts
+++ b/src/checkin/model/session/SessionData.ts
@@ -1,9 +1,10 @@
 import { CountryCode } from '../Schema'
-import { FlightData } from './FlightData'
+import { FlightData, SeatInformation } from './FlightData'
 
 export interface SessionData {
   country: CountryCode
   flights: FlightData[]
   passengers: number
   agreementSigned?: boolean
+  seats?: SeatInformation[]
 }

--- a/src/checkin/services/CheckInFlow.ts
+++ b/src/checkin/services/CheckInFlow.ts
@@ -5,6 +5,8 @@ import AgreementSignStep from './flow/step/AgreementSignStep'
 import CompleteCheckinStep from './flow/step/CompleteCheckinStep'
 import PassportInformationStep from './flow/step/PassportInformationStep'
 import ValidateSessionStep from './flow/step/ValidateSessionStep'
+import RequestSeatsStep from './flow/step/RequestSeatsStep'
+import CaptureSeatsStep from './flow/step/CaptureSeatsStep'
 
 export default class CheckinFlow extends FlowStrategy {
 
@@ -12,6 +14,8 @@ export default class CheckinFlow extends FlowStrategy {
     flowExecuter
       .and(new ValidateSessionStep())
       .and(new PassportInformationStep())
+      .and(new RequestSeatsStep())
+      .and(new CaptureSeatsStep())
       .and(new AgreementSignStep())
       .and(new CompleteCheckinStep())
 

--- a/src/checkin/services/CheckinFlow.spec.ts
+++ b/src/checkin/services/CheckinFlow.spec.ts
@@ -22,6 +22,8 @@ describe('[ Services / CheckInFlow ]', () => {
     const expectedSteps = [
       'ValidateSessionStep',
       'PassportInformationStep',
+      'RequestSeatsStep',
+      'CaptureSeatsStep',
       'AgreementSignStep',
       'CompleteCheckinStep'
     ]
@@ -29,8 +31,8 @@ describe('[ Services / CheckInFlow ]', () => {
     jest.spyOn(flowExecuterMock, 'and')
 
     await checkinFlow.checkIn(flowExecuterMock, requestData)
-
-    expect(flowExecuterMock.and).toHaveBeenCalledTimes(4)
+    const expectedNumberOfAddedSteps = expectedSteps.length
+    expect(flowExecuterMock.and).toHaveBeenCalledTimes(expectedNumberOfAddedSteps)
     expect(flowExecuterMock.getStepsExecution()).toEqual(expectedSteps)
   })
 })

--- a/src/checkin/services/flow/FlowExecuter.ts
+++ b/src/checkin/services/flow/FlowExecuter.ts
@@ -1,7 +1,6 @@
 import { Context } from '../../model/Context'
 import StepTemplate from './StepTemplate'
 
-// Using chain of responsability
 export default class FlowExecuter {
 
   protected readonly steps: StepTemplate[] = []

--- a/src/checkin/services/flow/step/AgreementSignStep.spec.ts
+++ b/src/checkin/services/flow/step/AgreementSignStep.spec.ts
@@ -64,7 +64,8 @@ function wireContextMockWithAgreementInSession(agreementSigned: boolean): Contex
       agreementSigned,
       country: context.getSession().data.country,
       flights: context.getSession().data.flights,
-      passengers: context.getSession().data.passengers
+      passengers: context.getSession().data.passengers,
+      seats: context.getSession().data.seats
     })
   )
 

--- a/src/checkin/services/flow/step/CaptureSeatsStep.spec.ts
+++ b/src/checkin/services/flow/step/CaptureSeatsStep.spec.ts
@@ -1,0 +1,42 @@
+import { MockContext } from '@testMocks/model/Context.mock'
+import { Context } from '../../../model/Context'
+import CaptureSeatsInfoStep from './CaptureSeatsStep'
+import { SeatInformation } from '../../../model/session/FlightData'
+
+describe('[ Step / CapturetSeatsStep ]', () => {
+  const step = new CaptureSeatsInfoStep()
+
+  describe('Test when it should be execute', () => {
+    it('should return true when the number of assigned seats is equal to the number of required assigned seats', () => {
+      const context: Context = new MockContext()
+      context.withRequestBuilder(requestBuilder => requestBuilder
+        .fields({ seats_required: 1 })
+        .seat([{ seatNumber: '1', flight: 'ABC123' }]))
+      expect(context.getRequest().seat?.length).toBe(context.getRequest().fields?.seats_required as number)
+    })
+
+    it('should return true when the seats that were assigned are sent to the session.', async () => {
+      const context: Context = wireContextMock([])
+      const response = await step.onExecute(context)
+
+      expect(response).toBeTruthy()
+      expect(context.getSession().data.seats).toStrictEqual(context.getRequest().seat)
+    })
+  })
+})
+
+function wireContextMock(seatsSigned: SeatInformation[]): Context {
+  const context: Context = new MockContext()
+  context.withSessionBuilder(sessionBuilder => sessionBuilder
+    .data({
+      country: context.getSession().data.country,
+      flights: context.getSession().data.flights,
+      passengers: context.getSession().data.passengers,
+      seats: seatsSigned
+    })
+  ).withRequestBuilder(requestBuilder => requestBuilder
+    .fields({ seats_required: 1 })
+    .seat([{ seatNumber: '1', flight: 'ABC123' }])
+  )
+  return context
+}

--- a/src/checkin/services/flow/step/CaptureSeatsStep.ts
+++ b/src/checkin/services/flow/step/CaptureSeatsStep.ts
@@ -1,0 +1,40 @@
+import { Context } from '../../../model/Context'
+import { Builder } from 'builder-pattern'
+import { SessionData } from '../../../model/session/SessionData'
+import StepTemplate from '../StepTemplate'
+
+export default class CaptureSeatsStep extends StepTemplate {
+  when(context: Context): boolean {
+    const session = context.getSession()
+    return (!session.data.seats ?? false)
+  }
+
+  onExecute(context: Context): Promise<boolean> {
+    const session = context.getSession()
+    const requestData = context.getRequest()
+    const amountSeats = requestData.fields?.seats_required as number
+
+    if (amountSeats !== requestData?.seat?.length) {
+      context = context.withResponseBuilder((responseBuilder) => responseBuilder
+        .status('seats_assignation_required')
+        .requiredFiles({ seats_required: null })
+      )
+      return Promise.resolve(false)
+    }
+
+    const seats = requestData.seat?.map(seat => ({
+      seatNumber: seat.seatNumber,
+      flight: seat.flight
+    }))
+
+    context = context.withSessionBuilder((sessionBuilder) => sessionBuilder
+      .data(
+        Builder<SessionData>(session.data)
+          .seats(seats)
+          .build()
+      )
+    )
+    return Promise.resolve(true)
+  }
+
+}

--- a/src/checkin/services/flow/step/RequestSeatsStep.spec.ts
+++ b/src/checkin/services/flow/step/RequestSeatsStep.spec.ts
@@ -1,0 +1,57 @@
+import { MockContext } from '@testMocks/model/Context.mock'
+import RequestSeatsStep from './RequestSeatsStep'
+import { Context } from '../../../model/Context'
+import { SeatInformation } from '../../../model/session/FlightData'
+
+describe('[ Step / RequestSeatsStep ]', () => {
+  const step = new RequestSeatsStep()
+
+  describe('Test when it should be execute', () => {
+    it('should return true when seats has not been signed', () => {
+      const context: Context = wireContextMockWithSeatsInSession([])
+      const result = step.when(context)
+
+      expect(result).toBeTruthy()
+    })
+
+    it('should return false when seats is signed', () => {
+      const context: Context = wireContextMockWithSeatsInSession([{ seatNumber: '1', flight: 'ABC123' }, { seatNumber: '1', flight: 'XYZ456' }])
+      const result = step.when(context)
+
+      expect(result).toBeFalsy()
+    })
+  })
+
+  describe('Testing at execution', () => {
+    it('should filled seats', async () => {
+      const context = new MockContext()
+      const response = step.onExecute(context)
+      expect(response).toBeTruthy()
+    })
+
+    it('should request the seat to the user if it is not signed', async () => {
+      const context: Context = wireContextMockWithSeatsInSession([])
+      context.withRequestBuilder(requestBuilder => requestBuilder
+        .fields({ seats_required: null })
+      )
+
+      const result = await step.onExecute(context)
+      expect(result).toBeFalsy()
+      expect(context.getResponse().requiredFiles?.seats_required).toBeNull()
+    })
+  })
+})
+
+function wireContextMockWithSeatsInSession(seatsSigned: SeatInformation[]): Context {
+  const context: Context = new MockContext()
+  context.withSessionBuilder(sessionBuilder => sessionBuilder
+    .data({
+      country: context.getSession().data.country,
+      flights: context.getSession().data.flights,
+      passengers: context.getSession().data.passengers,
+      seats: seatsSigned
+    })
+  )
+
+  return context
+}

--- a/src/checkin/services/flow/step/RequestSeatsStep.ts
+++ b/src/checkin/services/flow/step/RequestSeatsStep.ts
@@ -1,0 +1,42 @@
+import { Context } from '../../../model/Context'
+import { Session } from '../../../model/session'
+import StepTemplate from '../StepTemplate'
+
+export default class RequestSeatsStep extends StepTemplate {
+  when(context: Context): boolean {
+    const session = context.getSession()
+    return session.data.seats?.length === 0 ?? false
+  }
+
+  onExecute(context: Context): Promise<boolean> {
+    const session = context.getSession()
+    if (this.areSeatsMissing(session)) {
+      context = context.withResponseBuilder((responseBuilder) => responseBuilder
+        .status('seats_assignation_required')
+        .requiredFiles({ seats_required: null }))
+      return Promise.resolve(false)
+    }
+
+    if (!this.areSeatsAssignedCorrectly(session)) {
+      this.rejectRequest(context)
+      return Promise.resolve(false)
+    }
+    return Promise.resolve(true)
+  }
+
+  private rejectRequest(context: Context): Context {
+    return context.withResponseBuilder(
+      (responseBulder) => responseBulder
+        .status('rejected')
+    )
+  }
+
+  private areSeatsMissing(session: Session): boolean {
+    return !session.data.seats || session.data.seats.length === 0
+  }
+
+  private areSeatsAssignedCorrectly(session: Session): boolean {
+    return session.data.seats?.length !== (session.data.passengers * session.data.flights.length)
+  }
+
+}

--- a/src/http/model/Request.ts
+++ b/src/http/model/Request.ts
@@ -1,5 +1,6 @@
 import { UUID } from 'crypto'
 import { CountryCode, RequiredField } from '../../checkin/model/Schema'
+import { SeatInformation } from '../../checkin/model/session/FlightData'
 
 export interface RequestData {
   country: CountryCode
@@ -9,4 +10,5 @@ export interface RequestData {
   flightNumbers: string[]
   passengers: number
   fields?: Partial<Record<RequiredField, unknown>>
+  seat?: SeatInformation[]
 }

--- a/src/http/model/Response.ts
+++ b/src/http/model/Response.ts
@@ -3,6 +3,6 @@ import { RequiredField } from '../../checkin/model/Schema'
 
 export interface ResponseData {
   sessionId: UUID
-  status: 'user_information_required' | 'completed' | 'rejected'
+  status: 'user_information_required' | 'completed' | 'rejected' | 'seats_assignation_required'
   requiredFiles?: Partial<Record<RequiredField, unknown>>
 }

--- a/test/integration/framework/userInteraction.ts
+++ b/test/integration/framework/userInteraction.ts
@@ -33,6 +33,18 @@ const fillPassport = (app: Application, requiredData: RequiredData, data?: Parti
   { fields: { passport_number: 'G123' }, ...data }
 )
 
+const requestSeats = (app: Application, requiredData: RequiredData, data?: Partial<RequestData>): Promise<Response> => continueRequest(
+  app,
+  requiredData,
+  { fields: { seats_required: 2 }, ...data }
+)
+
+const captureSeats = (app: Application, requiredData: RequiredData, data?: Partial<RequestData>): Promise<Response> => continueRequest(
+  app,
+  requiredData,
+  { fields: { seats_required: 2 }, ...data }
+)
+
 const signLegalAgreement = (app: Application, requiredData: RequiredData, data?: Partial<RequestData>): Promise<Response> => continueRequest(
   app,
   requiredData,
@@ -44,5 +56,7 @@ export default {
   initSessionWithPassport,
   continue: continueRequest,
   fillPassport,
+  requestSeats,
+  captureSeats,
   signLegalAgreement
 }

--- a/test/integration/framework/verify.ts
+++ b/test/integration/framework/verify.ts
@@ -8,6 +8,13 @@ const requiredField = (requiredFiled: RequiredField, response: Response): void =
   expect(response.body.requiredFiles[requiredFiled]).toBeDefined()
 }
 
+const requiredSeatsAssignation = (requiredFiled: RequiredField, response: Response): void => {
+  expect(response.headers['content-type']).toEqual(expect.stringContaining('json'))
+  expect(response.body.status).toBe('seats_assignation_required')
+  expect(response.body.requiredFiles).toBeDefined()
+  expect(response.body.requiredFiles[requiredFiled]).toBeDefined()
+}
+
 const completed = (response: Response): void => {
   expect(response.headers['content-type']).toEqual(expect.stringContaining('json'))
   expect(response.body.status).toBe('completed')
@@ -20,7 +27,8 @@ const rejected = (response: Response): void => {
 
 export default {
   userInformation: {
-    requiredField
+    requiredField,
+    requiredSeatsAssignation
   },
   status: {
     rejected,

--- a/test/integration/standardFlow.integration.test.ts
+++ b/test/integration/standardFlow.integration.test.ts
@@ -23,8 +23,38 @@ describeFlowTest('Testing Standard checkin Flow', (app) => {
     verify.userInformation.requiredField('passport_number', response)
   })
 
-  it('should be asked to sign the legal agreement before completing the check in', async () => {
+  it('should reject if no seats are provided', async () => {
+    const userId = '123'
+    const sessionId = await userInteraction.initSession(app, country, { userId })
+    const sessionInformation = { sessionId, country }
 
+    let response = await userInteraction.continue(app, sessionInformation)
+    response = await userInteraction.requestSeats(app, sessionInformation)
+
+    verify.status.rejected(response)
+  })
+
+  it('should reject if seats are not assigned correctly', async () => {
+    const userId = '123'
+    const sessionId = await userInteraction.initSession(app, country, { userId })
+    const sessionInformation = { sessionId, country }
+
+    let response = await userInteraction.continue(app, sessionInformation)
+    response = await userInteraction.requestSeats(app, sessionInformation)
+
+    verify.status.rejected(response)
+  })
+
+  it('should have captured the seats before signing the legal agreement ', async () => {
+    const sessionId = await userInteraction.initSessionWithPassport(app, country)
+    const sessionInformation = { sessionId, country }
+
+    let response = await userInteraction.continue(app, sessionInformation)
+    response = await userInteraction.captureSeats(app, sessionInformation)
+    verify.userInformation.requiredSeatsAssignation('seats_required', response)
+  })
+
+  it('should be asked to sign the legal agreement before completing the check in', async () => {
     const sessionId = await userInteraction.initSessionWithPassport(app, country)
 
     const response = await userInteraction.continue(app, { sessionId, country })

--- a/test/mocks/model/RequestData.mock.ts
+++ b/test/mocks/model/RequestData.mock.ts
@@ -29,6 +29,7 @@ const generateRequestDataMock = (mockedData?: Partial<RequestData>): RequestData
       .userId(mockedData.userId ?? MOCKED_REQUEST_DATA.userId)
       .flightNumbers(mockedData.flightNumbers ?? MOCKED_REQUEST_DATA.flightNumbers)
       .fields(mockedData.fields ?? MOCKED_REQUEST_DATA.fields)
+      .seat(mockedData.seat ?? MOCKED_REQUEST_DATA.seat)
   }
 
   return builder.build()

--- a/test/mocks/model/Session.mock.ts
+++ b/test/mocks/model/Session.mock.ts
@@ -34,6 +34,16 @@ const MOCK_SESSION: Session = {
         }
       }
     ],
+    seats: [
+      {
+        seatNumber: '1',
+        flight: 'ABC123'
+      },
+      {
+        seatNumber: '1',
+        flight: 'XYZ456'
+      }
+    ],
     passengers: 1
   },
   userInformation: {
@@ -62,6 +72,7 @@ const fillSessionWithUserMockData = (mockedData: Partial<Session>, builder: IBui
       .agreementSigned(mockedData.data.agreementSigned ?? false)
       .country(mockedData.data.country ?? MOCK_SESSION.data.country)
       .flights(mockedData.data.flights ?? MOCK_SESSION.data.flights)
+      .seats(mockedData.data.seats ?? MOCK_SESSION.data.seats)
       .build()
 
     builder = builder.data(data)


### PR DESCRIPTION
Background
Let the users select the seats numbers.

Aceptance criteria:

- After the passport collection it should request the seats for the passengers.
- If seats don't match per passenger and flights then ask again. Meaning if session has 2 passengers and 2 seats, then it should be 4 seats assigned.

Technical Overview.

- The session already capture the number of passengers in the SessionData
- Create a new property in SessionData that contains the seats in format:

```
[
 { seatNumber: 'string', flight: 'flightNumber' }
]
```

Create 2 steps
Request seats step:
Check if that is filled in Session if not, request it by sending  in the ResponseData a new status: seats_assignation_required

Capture seats step
If request has filled a property called seats in the format equal as the one in session and, the number of seats is valid then capture the information in the session.